### PR TITLE
Fix sorting considers diacritics

### DIFF
--- a/src/app/services/aptitudes/aptitude.service.ts
+++ b/src/app/services/aptitudes/aptitude.service.ts
@@ -12,6 +12,7 @@ import { Aptitude } from './models/aptitude';
 import { Immunite } from '../../models/immunite';
 import { Resistance, ResistanceItem } from '../../models/resistance';
 import { Statistique } from '../../models/statistique';
+import { tap } from 'rxjs/operators';
 
 @Injectable()
 export class AptitudeService {
@@ -24,7 +25,13 @@ export class AptitudeService {
   ) { }
 
   getAptitudes(): Observable<Aptitude[]> {
-    return this.db.colWithIds$('aptitudes', ref => ref.orderBy("nom"));
+	return this.db.colWithIds$('aptitudes', ref => ref.orderBy("nom")).pipe(
+		tap(results => {
+			results.sort((a: Aptitude, b: Aptitude) => {
+				return a.nom.localeCompare(b.nom);
+			})
+		})
+	);
   }
 
   getAptitude(id: string): Observable<Aptitude> {

--- a/src/app/services/classes/classe.service.ts
+++ b/src/app/services/classes/classe.service.ts
@@ -19,6 +19,7 @@ import { StatistiqueService } from '../statistique.service';
 import { Resistance } from '../../models/resistance';
 import { Statistique } from '../../models/statistique';
 import { Immunite } from '../../models/immunite';
+import { tap } from 'rxjs/operators';
 
 @Injectable()
 export class ClasseService {
@@ -33,7 +34,13 @@ export class ClasseService {
   ) { }
 
   getClasses(): Observable<Classe[]> {
-    return this.db.colWithIds$('classes', ref => ref.orderBy("nom"));
+	return this.db.colWithIds$('classes', ref => ref.orderBy("nom")).pipe(
+		tap(results => {
+			results.sort((a: Classe, b: Classe) => {
+				return a.nom.localeCompare(b.nom);
+			})
+		})
+	);
   }
 
   getClasse(id: string): Observable<Classe> {
@@ -89,7 +96,13 @@ export class ClasseService {
   }
 
   getClassesPrestige(): Observable<Classe[]> {
-    return this.db.colWithIds$('classes', ref => ref.where('prestige', '==', true).orderBy("nom"));
+	return this.db.colWithIds$('classes', ref => ref.where('prestige', '==', true).orderBy("nom")).pipe(
+		tap(results => {
+			results.sort((a: Classe, b: Classe) => {
+				return a.nom.localeCompare(b.nom);
+			})
+		})
+	);
   }
 
   //#region Maps

--- a/src/app/services/domaines/domaine-service.ts
+++ b/src/app/services/domaines/domaine-service.ts
@@ -10,6 +10,7 @@ import { Domaine } from './models/domaine';
 import { Sort } from '../sorts/models/sort';
 import { Classe } from '../classes/models/classe';
 import { ClasseService } from '../classes/classe.service';
+import { tap } from 'rxjs/operators';
 
 @Injectable()
 export class DomaineService {
@@ -23,7 +24,13 @@ export class DomaineService {
   ) { }
 
   getDomaines(): Observable<Domaine[]> {
-    return this.db.colWithIds$('domaines', ref => ref.orderBy("nom"));
+	return this.db.colWithIds$('domaines', ref => ref.orderBy("nom")).pipe(
+		tap(results => {
+			results.sort((a: Domaine, b: Domaine) => {
+				return a.nom.localeCompare(b.nom);
+			})
+		})
+	);
   }
 
   getDomaine(id: string): Observable<Domaine> {

--- a/src/app/services/dons/don.service.ts
+++ b/src/app/services/dons/don.service.ts
@@ -10,6 +10,7 @@ import { Immunite } from '../../models/immunite';
 import { Race } from '../races/models/race';
 import { Resistance } from '../../models/resistance';
 import { Statistique } from '../../models/statistique';
+import { tap } from 'rxjs/operators';
 import * as firebase from 'firebase/app';
 import 'firebase/firestore';
 
@@ -24,7 +25,13 @@ export class DonService {
   ) { }
 
   getDons(): Observable<Don[]> {
-    return this.db.colWithIds$('dons', ref => ref.orderBy("nom"));
+	return this.db.colWithIds$('dons', ref => ref.orderBy("nom")).pipe(
+		tap(results => {
+			results.sort((a : Don, b: Don) => {
+				return a.nom.localeCompare(b.nom);
+			})
+		})
+	);
   }
 
   getDon(id: string): Observable<Don> {

--- a/src/app/services/races/race.service.ts
+++ b/src/app/services/races/race.service.ts
@@ -13,6 +13,7 @@ import { Don } from '../dons/models/don';
 import { Immunite } from '../../models/immunite';
 import { Sort } from '../sorts/models/sort';
 import { Statistique } from '../../models/statistique';
+import { tap } from 'rxjs/operators';
 
 @Injectable()
 export class RaceService {
@@ -27,7 +28,12 @@ export class RaceService {
 
   getRaces(): Observable<Race[]> {
 
-    let races: Observable<Race[]> = this.db.colWithIds$('races', ref => ref.orderBy("nom")).mergeMap((races: Race[]) => {
+	let races: Observable<Race[]> = this.db.colWithIds$('races', ref => ref.orderBy("nom")).pipe(
+	tap(results => {
+		results.sort((a: Race, b: Race) => {
+			return a.nom.localeCompare(b.nom);
+		})
+	})).mergeMap((races: Race[]) => {
 
       races.forEach(race => {
 

--- a/src/app/services/sorts/sort.service.ts
+++ b/src/app/services/sorts/sort.service.ts
@@ -10,6 +10,7 @@ import { Ecole } from '../../models/ecole';
 import { Porte } from '../../models/porte';
 import { Duree } from '../../models/duree';
 import { Zone } from '../../models/zone';
+import { tap } from 'rxjs/operators';
 
 @Injectable()
 export class SortService {
@@ -23,7 +24,13 @@ export class SortService {
   ) { }
 
   getSorts(): Observable<Sort[]> {
-    return this.db.colWithIds$('sorts', ref => ref.orderBy("nom"));
+	return this.db.colWithIds$('sorts', ref => ref.orderBy("nom")).pipe(
+		tap(results => {
+			results.sort((a: Sort, b: Sort) => {
+				return a.nom.localeCompare(b.nom)
+			});
+		})
+	);
   }
 
   getSort(id: string): Observable<Sort> {

--- a/src/app/services/sorts/sort.service.ts
+++ b/src/app/services/sorts/sort.service.ts
@@ -27,8 +27,8 @@ export class SortService {
 	return this.db.colWithIds$('sorts', ref => ref.orderBy("nom")).pipe(
 		tap(results => {
 			results.sort((a: Sort, b: Sort) => {
-				return a.nom.localeCompare(b.nom)
-			});
+				return a.nom.localeCompare(b.nom);
+			})
 		})
 	);
   }


### PR DESCRIPTION
Diacritics are left to the end of lists, but should not be considered when sorting.

For example:
![image](https://user-images.githubusercontent.com/48894940/58485990-0f35a580-8133-11e9-94b9-2d414fc5801b.png)
becomes
![image](https://user-images.githubusercontent.com/48894940/58486034-22487580-8133-11e9-9e13-0e1dbc3232b9.png)

Notice how "Âme sainte" does not appear on the first one(it's at the end of the list which is not visible), but appears on the second one.